### PR TITLE
[BB-496] Field type fixed

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -36,6 +36,14 @@ func NewClient() *FreshServiceClient {
 	}
 }
 
+type errorResponse struct {
+	MessageContent string `json:"message"`
+}
+
+func (er *errorResponse) Message() string {
+	return fmt.Sprintf("Error: %s", er.MessageContent)
+}
+
 func (f *FreshServiceClient) WithBearerToken(apiToken string) *FreshServiceClient {
 	f.auth.bearerToken = apiToken
 	return f
@@ -293,10 +301,13 @@ func (f *FreshServiceClient) doRequest(
 
 	switch method {
 	case http.MethodGet, http.MethodPut, http.MethodPost:
-		doOptions := []uhttp.DoOption{}
+		var errRes errorResponse
+		doOptions := []uhttp.DoOption{uhttp.WithErrorResponse(&errRes)}
+
 		if res != nil {
 			doOptions = append(doOptions, uhttp.WithResponse(&res))
 		}
+
 		resp, err = f.httpClient.Do(req, doOptions...)
 		if resp != nil {
 			defer resp.Body.Close()

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -28,9 +28,9 @@ type AgentDetailAPIData struct {
 }
 
 type AgentRole struct {
-	RoleID          int64    `json:"role_id,omitempty"`
-	AssignmentScope string   `json:"assignment_scope,omitempty"`
-	Groups          []string `json:"groups,omitempty"`
+	RoleID          int64   `json:"role_id,omitempty"`
+	AssignmentScope string  `json:"assignment_scope,omitempty"`
+	Groups          []int64 `json:"groups,omitempty"`
 }
 
 type RolesAPIData struct {


### PR DESCRIPTION
#### Description

- [x] Bug fix
- [ ] New feature

The inner field 'Groups' (Agent.Roles.Groups) is specified on the API documentation as an array of strings. However, the real response is an array of int64. Those are the IDs of the Groups in which a Role applies. 
Also, the ErrorResponse is now supported by the requests of this connector. It contains a message with more information about the errors of the API Server.


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
