### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-freshservice/main.go
+++ b/cmd/baton-freshservice/main.go
@@ -81,7 +81,7 @@ func getConnector(ctx context.Context, cfg *config.Freshservice) (types.Connecto
 		return nil, fmt.Errorf("invalid subdomain format: %q - should be just the subdomain portion (e.g., 'company' not 'company.freshservice.com')", fsDomain)
 	}
 
-	fsClient = fsClient.WithBearerToken(cfg.ApiKey).WithDomain(fsDomain).WithCategoryID(cfg.CategoryId)
+	fsClient = fsClient.WithBearerToken(cfg.ApiKey).WithDomain(fsDomain).WithCategoryID(cfg.CategoryId).WithBaseURL(cfg.BaseUrl)
 
 	cb, err := connector.New(ctx,
 		cfg.ApiKey,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,6 +59,11 @@ func (f *FreshServiceClient) WithCategoryID(categoryID string) *FreshServiceClie
 	return f
 }
 
+func (f *FreshServiceClient) WithBaseURL(baseURL string) *FreshServiceClient {
+	f.baseUrl = baseURL
+	return f
+}
+
 func (f *FreshServiceClient) GetCategoryID() string {
 	return f.categoryId
 }
@@ -100,7 +105,10 @@ func New(ctx context.Context, freshServiceClient *FreshServiceClient) (*FreshSer
 		return freshServiceClient, err
 	}
 
-	baseUrl := fmt.Sprintf("https://%s.freshservice.com/api/v2", domain)
+	baseUrl := freshServiceClient.baseUrl
+	if baseUrl == "" {
+		baseUrl = fmt.Sprintf("https://%s.freshservice.com/api/v2", domain)
+	}
 	if !isValidUrl(baseUrl) {
 		return nil, fmt.Errorf("the url : %s is not valid", baseUrl)
 	}

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,10 +7,11 @@ type Freshservice struct {
 	ApiKey string `mapstructure:"api-key"`
 	Domain string `mapstructure:"domain"`
 	CategoryId string `mapstructure:"category-id"`
+	BaseUrl string `mapstructure:"base-url"`
 	Ticketing bool `mapstructure:"ticketing"`
 }
 
-func (c* Freshservice) findFieldByTag(tagValue string) (any, bool) {
+func (c *Freshservice) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -42,11 +43,13 @@ func (c *Freshservice) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Freshservice) GetInt(fieldName string) int {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Freshservice API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	externalTicketField = field.TicketingField.ExportAs(field.ExportTargetGUI)
 	configurationFields = []field.SchemaField{apiKeyField, domainField, categoryField, BaseURLField, externalTicketField}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,8 +26,12 @@ var (
 		field.WithDisplayName("Category ID"),
 		field.WithDescription("The category id to filter service items to"),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Freshservice API URL (for testing)"),
+	)
 	externalTicketField = field.TicketingField.ExportAs(field.ExportTargetGUI)
-	configurationFields = []field.SchemaField{apiKeyField, domainField, categoryField, externalTicketField}
+	configurationFields = []field.SchemaField{apiKeyField, domainField, categoryField, BaseURLField, externalTicketField}
 )
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Freshservice API URL (for testing)"),
+		field.WithHidden(true),
 	)
 	externalTicketField = field.TicketingField.ExportAs(field.ExportTargetGUI)
 	configurationFields = []field.SchemaField{apiKeyField, domainField, categoryField, BaseURLField, externalTicketField}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-freshservice/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-freshservice --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.